### PR TITLE
11. GET /api/submissions/id state 렌더 방식 및 response problem 형태 수정

### DIFF
--- a/client/components/status/StatusList.tsx
+++ b/client/components/status/StatusList.tsx
@@ -36,38 +36,15 @@ function StatusList({ status }: StatusListProps) {
             },
           },
           {
-            path: 'result',
+            path: 'state',
             name: '결과',
             weight: 1,
-            format: (value) => {
-              if (value === 0) return '채점중';
-              if (value === 1) return '맞았습니다.';
-              if (value === 2) return '틀렸습니다.';
-              if (value === 3) return '시간 초과';
-              if (value === 4) return '컴파일 에러';
-              if (value === 5) return '런타임 에러';
-            },
-            style: {
-              row: (row: StatusSummary) => {
-                if (row.result === 1)
-                  return css`
-                    color: #508f56;
-                  `;
-                if (row.result === 2)
-                  return css`
-                    color: #d64040;
-                  `;
-                return css`
-                  color: #636971;
-                `;
-              },
-            },
           },
           {
             path: 'time',
             name: '시간',
             weight: 1,
-            format: (value: number) => `${value} ms`,
+            format: (value: number) => `${value ?? '--'} ms`,
           },
           {
             path: 'datetime',

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -70,7 +70,7 @@ interface StatusSummary {
   id: number;
   user: string;
   title: string;
-  result: number;
+  state: string;
   time: number;
   datetime: number;
 }

--- a/client/pages/status/[id].tsx
+++ b/client/pages/status/[id].tsx
@@ -40,7 +40,7 @@ function StatusDetail() {
       id: submission.submission.id,
       user: submission.submission.user,
       title: submission.problem.title,
-      result: submission.submission.stateId,
+      state: submission.submission.state,
       time: submission.submission.time,
       datetime: submission.submission.datetime,
     });

--- a/server/src/problems/problems.controller.ts
+++ b/server/src/problems/problems.controller.ts
@@ -19,6 +19,7 @@ import { PostTestCaseDTO } from './dtos/post-testcase.dto';
 import { UpdateProblemDTO } from './dtos/update-problem.dto';
 import { ProblemsService } from './problems.service';
 import { PostSubmissionDTO } from './dtos/post-submission.dto';
+import { Request } from 'express';
 
 @Controller('problems')
 export class ProblemsController {

--- a/server/src/submissions/submissions.service.ts
+++ b/server/src/submissions/submissions.service.ts
@@ -83,7 +83,7 @@ export class SubmissionsService {
     if (!problem) throw new NotFoundException('해당 문제가 없습니다.');
 
     const state = !result
-      ? '채점 중'
+      ? { name: '채점 중' }
       : await this.stateRepository.findOne({
           select: {
             name: true,
@@ -100,12 +100,14 @@ export class SubmissionsService {
         code: submission.code,
         language: language.language,
         datetime: submission.createdAt.getTime(),
-        state,
+        state: state.name,
         stateId: result?.stateId ?? 0,
-        time: result?.time ?? 0,
+        time: result?.time,
         memory: result?.memory ?? 0,
       },
-      problem,
+      problem: {
+        title: problem.title,
+      },
     };
   }
 }


### PR DESCRIPTION
## 개요
- #92 
     
## 작업사항
- GET /api/submissions/id
  - response problem 내용 모두 보내는 방식에서 필요한 title만 보내는 형태로 변경
  - response submissions state 또한 '채점중'과 { 'name': '정답' } 과 같이 두 가지 형태로 보내지는 이슈 -> { 'name' : 상태 } 로 통일
- 프론트
  - 기존 state.id로 프론트에서 조건을 걸어서 상태를 표시했으나 백엔드에서 상태를 바로 보내줘서 바로 state를 렌더 가능하도록 변경