### PR TITLE
docker 빌드 최적화

### DIFF
--- a/scoring-server/.dockerignore
+++ b/scoring-server/.dockerignore
@@ -1,0 +1,3 @@
+*
+!python
+!docker

--- a/scoring-server/docker/Dockerfile
+++ b/scoring-server/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y python3 build-essential
+RUN apt-get update && apt-get install -y python3-dev
 
 COPY ./python /judger
 


### PR DESCRIPTION
## 개요
- #160 
     
## 작업사항
- dockerignore 추가
  - 모든 파일 무시
  - python 폴더, docker 폴더 포함
- build-essential 전부 설치하지 않고 python3-dev로 충분하다 판단
  - 이미지 크기 418 MB에서 210 MB로 축소
