### PR TITLE
fix: 이전 테스트 케이스 출력 파일 제거

### DIFF
--- a/scoring-server/python/run.py
+++ b/scoring-server/python/run.py
@@ -301,6 +301,8 @@ if __name__ == "__main__":
             systemcall_names
         )
 
+        os.remove(output_path)
+
         if testcase_result != "정답":
             print_exit({"result": testcase_result})
 


### PR DESCRIPTION
## 개요
- 출력 파일을 제거하지 않으면 새로운 파일을 만드는 것이 아니라 이전에 작성된 파일의 앞부분에 덮어씌우기 때문에 채점이 제대로 진행되지 않는 문제가 있습니다.
     
## 작업사항
- 테스트 케이스마다 실행이 완료되면 해당 테스트 케이스에서 출력된 파일을 제거합니다.
