### PR TITLE
도커 컨테이너 여러 개 띄울 수 있도록 변경

### DIFF
--- a/scoring-server/docker/run.sh
+++ b/scoring-server/docker/run.sh
@@ -7,4 +7,4 @@ fi
 
 docker kill $NAME
 
-docker run -idt --rm --name $NAME scoring_docker /start.sh
+docker run --cpuset-cpus=$1 --cpus=1 -idt --rm --name $NAME scoring_docker /start.sh


### PR DESCRIPTION
## 개요
- #164 
     
## 작업사항
* 도커 컨테이너 개수는 env로 관리 가능
* 도커 컨테이너 CPU 개수 제한
     
## 변경로직(optional)
- 도커 컨테이너가 1개일 때 `isReady` 플래그 변수로 구분했던 방식을 `isReadyContainer` 배열큐로 관리하도록 변경함.
- `isReadyContainer` 에는 채점 가능한 도커 컨테이너의 번호를 넣어 관리함.