### PR TITLE
도커 컨테이너 여러 개 띄울 수 있도록 변경(dev -> main)

### DIFF
--- a/scoring-server/python/run.py
+++ b/scoring-server/python/run.py
@@ -301,6 +301,8 @@ if __name__ == "__main__":
             systemcall_names
         )
 
+        os.remove(output_path)
+
         if testcase_result != "정답":
             print_exit({"result": testcase_result})
 


### PR DESCRIPTION
#165
## 개요
- #164 
     
## 작업사항
* 도커 컨테이너 개수는 env로 관리 가능
* 도커 컨테이너 CPU 개수 제한
     
## 변경로직(optional)
- 도커 컨테이너가 1개일 때 `isReady` 플래그 변수로 구분했던 방식을 `isReadyContainer` 배열큐로 관리하도록 변경함.
- `isReadyContainer` 에는 채점 가능한 도커 컨테이너의 번호를 넣어 관리함.