### PR TITLE
fix: a 태그 겹침 문제 해결

### DIFF
--- a/client/pages/my-problem/index.tsx
+++ b/client/pages/my-problem/index.tsx
@@ -180,7 +180,7 @@ function MyProblem() {
                   },
                 },
                 {
-                  path: 'id',
+                  path: undefined,
                   name: '편집',
                   weight: 0.5,
                   style: {
@@ -188,11 +188,12 @@ function MyProblem() {
                       text-align: center;
                     `,
                   },
-                  format: (value: number) => (
-                    <Link href={`/my-problem/edit/${value}`}>
-                      <EditSvg />
-                    </Link>
-                  ),
+                  onclick: (e, row: MyProblemSummary) => {
+                    e.preventDefault();
+
+                    Router.push(`/my-problem/edit/${row.id}`);
+                  },
+                  format: () => <EditSvg />,
                 },
                 {
                   path: undefined,
@@ -215,7 +216,7 @@ function MyProblem() {
                   format: () => <DeleteSvg />,
                 },
                 {
-                  path: 'id',
+                  path: undefined,
                   name: 'TC 추가',
                   weight: 0.5,
                   style: {
@@ -223,11 +224,12 @@ function MyProblem() {
                       text-align: center;
                     `,
                   },
-                  format: (value: number) => (
-                    <Link href={`/my-problem/tc/${value}`}>
-                      <AddFileSvg />
-                    </Link>
-                  ),
+                  onclick: (e, row: MyProblemSummary) => {
+                    e.preventDefault();
+
+                    Router.push(`/my-problem/tc/${row.id}`);
+                  },
+                  format: () => <AddFileSvg />,
                 },
                 {
                   path: 'visible',


### PR DESCRIPTION
## 개요
- #75 
     
## 작업사항
- a 태그 겹침 문제 해결
  - 1차 시도
    - 두개의 a 태그를 부모 자식 관계가 아닌 형제 관계로 둬서 문제를 해결하는 방식 실패
    - 이벤트가 전달이 안되어서 전체에 걸려야하는 링크 이동이 되지 않는다.
    - https://stackoverflow.com/questions/9882916/are-you-allowed-to-nest-a-link-inside-of-a-link
  - 2차 시도
    - 모든 a 태그를 제거하고 onclick 이벤트로 작동하도록 수정
