### PR TITLE
fix: ip 주소 말고 세션을 사용해서 요청한 사람 확인

### DIFF
--- a/server/src/problems/throttler-behind-proxy.guard.ts
+++ b/server/src/problems/throttler-behind-proxy.guard.ts
@@ -4,6 +4,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
   protected getTracker(req: Record<string, any>): string {
-    return req.ips.length ? req.ips[0] : req.ip; // individualize IP extraction to meet your own needs
+    return `${req.session.userId}`; // individualize IP extraction to meet your own needs
   }
 }


### PR DESCRIPTION
## 개요
- #214 
     
## 작업사항
- ip 주소를 이용해서 요청 횟수 제한을 걸면 next가 nest를 호출하는 방식으로 작성된 서버에서는 정상적으로 동작하지 않았습니다. 그래서 ip 주소가 아니라 세션을 사용해 요청한 사람을 확인했습니다.
- 